### PR TITLE
Add simple PWA web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ python bot.py --mode simulate   # dry run
 python bot.py --mode live       # trade with real funds
 ```
 
+### Web Interface
+
+You can control the bot through a small web UI that also works as a
+Progressive Web App (PWA).
+
+```bash
+python webapp.py
+```
+
+Open `http://localhost:5000` in your browser to start or stop the bot
+and view its status.
+
 The console output shows open positions and profit/loss for each trade.
 This codebase is **not** production ready and should be used with
 caution. Review the source and extend the trading logic and risk

--- a/bot.py
+++ b/bot.py
@@ -39,6 +39,7 @@ class TradeBot:
         self.trades: List[Trade] = []
         self.aggressiveness = int(self.config.get('aggressiveness', 5))
         self.balance = float(self.config.get('starting_balance', 10000))
+        self.running = False
 
     def fetch_news_sentiment(self) -> float:
         """Placeholder for news sentiment analysis."""
@@ -146,9 +147,36 @@ class TradeBot:
         bar = "█" * self.aggressiveness + " " * (10 - self.aggressiveness)
         console.print(f"Balance: {self.balance:.2f} | Aggressiveness: {self.aggressiveness}/10 [{bar}]")
 
+    def stop(self):
+        """Stop the bot loop."""
+        self.running = False
+
+    def get_status(self) -> dict:
+        """Return current balance and trades for API usage."""
+        trades = [
+            {
+                'action': t.action,
+                'price': t.price,
+                'amount': t.amount,
+                'reason': t.reason,
+                'pnl': t.pnl,
+                'open': t.open,
+                'stop_loss': t.stop_loss,
+                'take_profit': t.take_profit,
+            }
+            for t in self.trades
+        ]
+        return {
+            'balance': self.balance,
+            'aggressiveness': self.aggressiveness,
+            'trades': trades,
+            'running': self.running,
+        }
+
     def run(self):
+        self.running = True
         symbol = 'BTC/USD'
-        while True:
+        while self.running:
             df = self.fetch_ohlc(symbol)
             df = self.apply_indicators(df)
             signal, reason = self.generate_signal(df)

--- a/dockerfile
+++ b/dockerfile
@@ -2,5 +2,5 @@ FROM python:3.10-slim
 WORKDIR /usr/src/app
 COPY . .
 RUN pip install --no-cache-dir -r requirements.txt
-CMD ["python", "bot.py"]
+CMD ["python", "webapp.py"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ pandas
 requests
 ta
 rich
+Flask
 

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TradeBot UI</title>
+    <link rel="manifest" href="/manifest.json">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+    <h1 class="mb-3">TradeBot Control Panel</h1>
+    <div class="mb-3">
+        <button id="startBtn" class="btn btn-success me-2">Start</button>
+        <button id="stopBtn" class="btn btn-danger">Stop</button>
+    </div>
+    <pre id="status"></pre>
+
+    <script src="/main.js"></script>
+    <script>
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('/service-worker.js');
+        }
+    </script>
+</body>
+</html>

--- a/static/main.js
+++ b/static/main.js
@@ -1,0 +1,23 @@
+async function startBot() {
+    const res = await fetch('/api/start', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({mode: 'simulate'})
+    });
+    updateStatus();
+}
+
+async function stopBot() {
+    await fetch('/api/stop', {method: 'POST'});
+    updateStatus();
+}
+
+async function updateStatus() {
+    const res = await fetch('/api/status');
+    const data = await res.json();
+    document.getElementById('status').textContent = JSON.stringify(data, null, 2);
+}
+
+document.getElementById('startBtn').addEventListener('click', startBot);
+document.getElementById('stopBtn').addEventListener('click', stopBot);
+updateStatus();

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,0 +1,7 @@
+{
+    "name": "TradeBot UI",
+    "short_name": "TradeBot",
+    "display": "standalone",
+    "start_url": "/",
+    "icons": []
+}

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,0 +1,16 @@
+self.addEventListener('install', (event) => {
+    event.waitUntil(
+        caches.open('tradebot-v1').then((cache) => cache.addAll([
+            '/',
+            '/index.html',
+            '/main.js',
+            '/manifest.json',
+        ]))
+    );
+});
+
+self.addEventListener('fetch', (event) => {
+    event.respondWith(
+        caches.match(event.request).then((response) => response || fetch(event.request))
+    );
+});

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,47 @@
+from threading import Thread
+
+from flask import Flask, jsonify, request, send_from_directory
+
+from bot import TradeBot, load_config
+
+app = Flask(__name__, static_folder='static', static_url_path='')
+
+bot = None
+bot_thread = None
+
+@app.route('/api/start', methods=['POST'])
+def start_bot():
+    global bot, bot_thread
+    if bot and bot.running:
+        return jsonify({'status': 'running'})
+    cfg_path = request.json.get('config', 'config.json')
+    mode = request.json.get('mode', 'simulate')
+    config = load_config(cfg_path)
+    bot = TradeBot(config, simulate=(mode == 'simulate'))
+    bot_thread = Thread(target=bot.run, daemon=True)
+    bot_thread.start()
+    return jsonify({'status': 'started'})
+
+@app.route('/api/stop', methods=['POST'])
+def stop_bot():
+    global bot
+    if bot:
+        bot.stop()
+    return jsonify({'status': 'stopped'})
+
+@app.route('/api/status')
+def status():
+    if bot:
+        return jsonify(bot.get_status())
+    return jsonify({'running': False})
+
+@app.route('/')
+def root():
+    return send_from_directory(app.static_folder, 'index.html')
+
+@app.route('/<path:path>')
+def static_proxy(path):
+    return send_from_directory(app.static_folder, path)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- implement `running` flag and `stop()` / `get_status()` helpers in `bot.py`
- add Flask based `webapp.py` with API endpoints and static file serving
- provide basic PWA UI (Bootstrap page, service worker, manifest)
- update README instructions
- update dockerfile and requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685322f483e88321b1aca888bed4ebb4