### PR TITLE
Fix config path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Tradebotv1
 
+The bot loads its configuration from `config.json` by default. You can
+override this path by setting the `CONFIG_PATH` environment variable.
+

--- a/bot.py
+++ b/bot.py
@@ -1,9 +1,11 @@
 import json
+import os
 import time
 
 def main():
     print("MoneyMaker5000 bot starting up...")
-    with open("config.json") as f:
+    config_path = os.getenv("CONFIG_PATH", "config.json")
+    with open(config_path) as f:
         config = json.load(f)
     print("Config loaded. Running in", config["trade_mode"], "mode.")
 


### PR DESCRIPTION
## Summary
- use CONFIG_PATH env var to locate `config.json`
- document how to override config path

## Testing
- `python -m py_compile bot.py`
- `python bot.py` *(killed after confirming startup)*

------
https://chatgpt.com/codex/tasks/task_e_6852e1573508832191049abdc76d8f58